### PR TITLE
feat: implement PetriVerse simulation app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+.vite/
+.DS_Store
+.env.local
+npm-debug.log*
+yarn-error.log*
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# petri-verse
+# PetriVerse
+
+PetriVerse（ペトリバース）は、ペトリ皿の中に広がる小さな生態系を再現するフロントエンド専用シミュレーターです。React + TypeScript をベースに Feature-Sliced Design を意識した構成で実装されています。
+
+## 主な機能
+
+- Canvas ベースの観察シーンで微生物・捕食者・環境の変化をリアルタイム描画。
+- 温度 / 酸素 / 水質 / 突然変異率を調整可能な環境パネル。
+- 高栄養 / 低栄養 / 毒性エサを散布するフィードアクション。
+- 世代交代や突然変異・捕食イベントを記録する進化ログ。
+- 出現した生物・イベントを自動登録し、JSON でエクスポート / インポートできる図鑑。
+- 進化や捕食の傾向を簡易的に集計するランキングビュー。
+
+## 開発
+
+```
+npm install
+npm run dev
+```
+
+> ネットワーク制限環境では依存パッケージの取得が行えない場合があります。その場合はローカルで依存関係を解決してからビルドを行ってください。
+
+## フォルダ構成（抜粋）
+
+```
+src/
+├── app              # プロバイダ、ルーティング、グローバルスタイル
+├── entities         # organism / predator / environment / food / encyclopediaEntry
+├── features         # feed-organism, encyclopedia などの機能単位
+├── widgets          # observationScene, environmentControl, evolutionHistory
+├── pages            # main / encyclopedia / ranking ページ
+└── shared           # 共通ロジック、定数、ユーティリティ
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PetriVerse</title>
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "petri-verse",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "format": "prettier --write \"src/**/*.{ts,tsx,css}\""
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-router-dom": "6.22.2",
+    "zustand": "4.5.2"
+  },
+  "devDependencies": {
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "@typescript-eslint/eslint-plugin": "6.7.4",
+    "@typescript-eslint/parser": "6.7.4",
+    "@vitejs/plugin-react": "4.2.1",
+    "eslint": "8.49.0",
+    "eslint-config-prettier": "9.0.0",
+    "eslint-plugin-react": "7.33.2",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "prettier": "3.0.3",
+    "typescript": "5.2.2",
+    "vite": "4.5.0"
+  }
+}

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
+  <circle cx="60" cy="60" r="58" stroke="#4fc3f7" stroke-width="4" fill="#0b0f1a" />
+  <circle cx="45" cy="45" r="12" fill="#7ef9c8" opacity="0.8" />
+  <circle cx="75" cy="70" r="18" fill="#ff80ab" opacity="0.7" />
+  <circle cx="35" cy="80" r="8" fill="#fff176" opacity="0.6" />
+  <path d="M30 30 C60 10 90 110 30 90" stroke="#81d4fa" stroke-width="3" fill="transparent" />
+</svg>

--- a/src/app/providers/SimulationProvider.tsx
+++ b/src/app/providers/SimulationProvider.tsx
@@ -1,0 +1,24 @@
+import React, { createContext, useContext, useMemo } from 'react';
+import { useLocalSimulationStore } from '../../shared/config/store';
+import type { SimulationStore } from '../../shared/config/types';
+
+const SimulationContext = createContext<SimulationStore | null>(null);
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export const SimulationProvider: React.FC<Props> = ({ children }) => {
+  const store = useLocalSimulationStore();
+  const value = useMemo(() => store, [store]);
+
+  return <SimulationContext.Provider value={value}>{children}</SimulationContext.Provider>;
+};
+
+export const useSimulation = (): SimulationStore => {
+  const context = useContext(SimulationContext);
+  if (!context) {
+    throw new Error('useSimulation must be used within SimulationProvider');
+  }
+  return context;
+};

--- a/src/app/routes/index.tsx
+++ b/src/app/routes/index.tsx
@@ -1,0 +1,16 @@
+import { createBrowserRouter } from 'react-router-dom';
+import { MainPage } from '../../pages/main/ui/MainPage';
+import { EncyclopediaPage } from '../../pages/encyclopedia/ui/EncyclopediaPage';
+import { RankingPage } from '../../pages/ranking/ui/RankingPage';
+import { Layout } from '../../shared/ui/Layout';
+
+export const AppRouter = createBrowserRouter([
+  {
+    element: <Layout />,
+    children: [
+      { path: '/', element: <MainPage /> },
+      { path: '/encyclopedia', element: <EncyclopediaPage /> },
+      { path: '/ranking', element: <RankingPage /> }
+    ]
+  }
+]);

--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -1,0 +1,29 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: radial-gradient(circle at top, #101b2d, #05080d 65%);
+  color: #f3f8ff;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+#root {
+  min-height: 100vh;
+  display: flex;
+}
+
+button {
+  font-family: inherit;
+}

--- a/src/entities/encyclopediaEntry/model/types.ts
+++ b/src/entities/encyclopediaEntry/model/types.ts
@@ -1,0 +1,13 @@
+export type EncyclopediaCategory = 'organism' | 'predator' | 'event' | 'environment';
+
+export interface EncyclopediaEntry {
+  id: string;
+  name: string;
+  category: EncyclopediaCategory;
+  description: string;
+  discoveredAt: number;
+  thumbnail?: string;
+  details: Record<string, string | number>;
+  favorite?: boolean;
+  conditions?: string;
+}

--- a/src/entities/environment/lib/createEnvironment.ts
+++ b/src/entities/environment/lib/createEnvironment.ts
@@ -1,0 +1,16 @@
+import type { Environment } from '../model/types';
+
+export const createEnvironment = (): Environment => ({
+  temperature: 26,
+  oxygen: 0.8,
+  acidity: 7,
+  mutationRate: 0.1
+});
+
+export const clampEnvironment = (environment: Environment): Environment => ({
+  temperature: Math.min(40, Math.max(5, environment.temperature)),
+  oxygen: Math.min(1, Math.max(0, environment.oxygen)),
+  acidity: Math.min(14, Math.max(0, environment.acidity)),
+  mutationRate: Math.min(0.5, Math.max(0.01, environment.mutationRate)),
+  event: environment.event
+});

--- a/src/entities/environment/model/types.ts
+++ b/src/entities/environment/model/types.ts
@@ -1,0 +1,10 @@
+export interface Environment {
+  temperature: number;
+  oxygen: number;
+  acidity: number;
+  mutationRate: number;
+  event?: {
+    name: string;
+    expiresAt: number;
+  };
+}

--- a/src/entities/food/lib/createFood.ts
+++ b/src/entities/food/lib/createFood.ts
@@ -1,0 +1,10 @@
+import { nanoid } from '../../../shared/lib/nanoid';
+import type { FoodEvent, FoodType } from '../model/types';
+
+export const createFoodEvent = (type: FoodType, amount: number): FoodEvent => ({
+  id: nanoid(),
+  type,
+  createdAt: Date.now(),
+  amount,
+  decay: type === 'toxic' ? 0.05 : 0.02
+});

--- a/src/entities/food/model/types.ts
+++ b/src/entities/food/model/types.ts
@@ -1,0 +1,9 @@
+export type FoodType = 'high' | 'low' | 'toxic';
+
+export interface FoodEvent {
+  id: string;
+  type: FoodType;
+  createdAt: number;
+  amount: number;
+  decay: number;
+}

--- a/src/entities/organism/lib/createOrganism.ts
+++ b/src/entities/organism/lib/createOrganism.ts
@@ -1,0 +1,63 @@
+import { nanoid } from '../../../shared/lib/nanoid';
+import { randomInRange, randomItem } from '../../../shared/lib/random';
+import type { Organism, OrganismTraits } from '../model/types';
+
+const shapes: OrganismTraits['shape'][] = ['circle', 'amoeba', 'spike'];
+const colors = ['#7ef9c8', '#81d4fa', '#ff80ab', '#fff176', '#ce93d8'];
+const foods: OrganismTraits['preferredFood'][] = ['high', 'low', 'toxic'];
+
+export interface CreateOrganismParams {
+  position?: { x: number; y: number };
+  generation?: number;
+  parentTraits?: OrganismTraits;
+}
+
+export const createOrganism = ({
+  position,
+  generation = 1,
+  parentTraits
+}: CreateOrganismParams = {}): Organism => {
+  const traits: OrganismTraits = parentTraits
+    ? mutateTraits(parentTraits)
+    : {
+        speed: randomInRange(10, 30),
+        fertility: randomInRange(0.2, 0.6),
+        resilience: randomInRange(0.2, 1),
+        preferredFood: randomItem(foods),
+        color: randomItem(colors),
+        shape: randomItem(shapes)
+      };
+
+  return {
+    id: nanoid(),
+    generation,
+    age: 0,
+    lifespan: randomInRange(60, 200),
+    position: position ?? { x: randomInRange(50, 550), y: randomInRange(50, 350) },
+    velocity: { x: randomInRange(-traits.speed, traits.speed), y: randomInRange(-traits.speed, traits.speed) },
+    size: randomInRange(8, 18),
+    energy: randomInRange(50, 100),
+    traits,
+    status: 'idle',
+    discoveredAt: Date.now()
+  };
+};
+
+export const mutateTraits = (traits: OrganismTraits): OrganismTraits => {
+  const mutationRate = 0.15;
+  const mutateValue = (value: number, min: number, max: number) =>
+    Math.min(max, Math.max(min, value + randomInRange(-mutationRate, mutationRate) * value));
+
+  const maybeChangeFood = Math.random() < 0.25 ? randomItem(foods) : traits.preferredFood;
+  const maybeChangeShape = Math.random() < 0.2 ? randomItem(shapes) : traits.shape;
+  const maybeChangeColor = Math.random() < 0.2 ? randomItem(colors) : traits.color;
+
+  return {
+    speed: mutateValue(traits.speed, 5, 40),
+    fertility: mutateValue(traits.fertility, 0.1, 0.9),
+    resilience: mutateValue(traits.resilience, 0.1, 1.5),
+    preferredFood: maybeChangeFood,
+    shape: maybeChangeShape,
+    color: maybeChangeColor
+  };
+};

--- a/src/entities/organism/model/types.ts
+++ b/src/entities/organism/model/types.ts
@@ -1,0 +1,24 @@
+export type FoodPreference = 'high' | 'low' | 'toxic';
+
+export interface OrganismTraits {
+  speed: number;
+  fertility: number;
+  resilience: number;
+  preferredFood: FoodPreference;
+  color: string;
+  shape: 'circle' | 'amoeba' | 'spike';
+}
+
+export interface Organism {
+  id: string;
+  generation: number;
+  age: number;
+  lifespan: number;
+  position: { x: number; y: number };
+  velocity: { x: number; y: number };
+  size: number;
+  energy: number;
+  traits: OrganismTraits;
+  status: 'idle' | 'feeding' | 'evading' | 'mutating';
+  discoveredAt: number;
+}

--- a/src/entities/predator/lib/createPredator.ts
+++ b/src/entities/predator/lib/createPredator.ts
@@ -1,0 +1,19 @@
+import { nanoid } from '../../../shared/lib/nanoid';
+import { randomInRange, randomItem } from '../../../shared/lib/random';
+import type { Predator } from '../model/types';
+
+export const createPredator = (): Predator => {
+  const behavior = randomItem(['agile', 'lurker'] as const);
+  const size = randomInRange(40, 65);
+  const speed = behavior === 'agile' ? randomInRange(40, 70) : randomInRange(15, 35);
+  return {
+    id: nanoid(),
+    behavior,
+    age: 0,
+    lifespan: behavior === 'agile' ? randomInRange(30, 60) : randomInRange(90, 140),
+    position: { x: randomInRange(80, 520), y: randomInRange(60, 340) },
+    velocity: { x: randomInRange(-speed, speed), y: randomInRange(-speed, speed) },
+    size,
+    spawnTime: Date.now()
+  };
+};

--- a/src/entities/predator/model/types.ts
+++ b/src/entities/predator/model/types.ts
@@ -1,0 +1,12 @@
+export type PredatorBehavior = 'agile' | 'lurker';
+
+export interface Predator {
+  id: string;
+  behavior: PredatorBehavior;
+  age: number;
+  lifespan: number;
+  position: { x: number; y: number };
+  velocity: { x: number; y: number };
+  size: number;
+  spawnTime: number;
+}

--- a/src/features/encyclopedia/ui/EncyclopediaList.tsx
+++ b/src/features/encyclopedia/ui/EncyclopediaList.tsx
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+import type { EncyclopediaEntry } from '../../../entities/encyclopediaEntry/model/types';
+import { useSimulation } from '../../../app/providers/SimulationProvider';
+import './encyclopedia-list.css';
+
+const categoryLabel: Record<EncyclopediaEntry['category'], string> = {
+  organism: '微生物',
+  predator: '捕食者',
+  event: 'イベント',
+  environment: '環境'
+};
+
+export const EncyclopediaList = () => {
+  const { encyclopedia, toggleFavorite } = useSimulation();
+
+  const grouped = useMemo(() => {
+    const map = new Map<EncyclopediaEntry['category'], EncyclopediaEntry[]>();
+    encyclopedia.forEach((entry) => {
+      const list = map.get(entry.category) ?? [];
+      list.push(entry);
+      map.set(entry.category, list);
+    });
+    return Array.from(map.entries());
+  }, [encyclopedia]);
+
+  return (
+    <div className="encyclopedia-list">
+      {grouped.map(([category, entries]) => (
+        <section key={category}>
+          <header>
+            <h3>{categoryLabel[category]}</h3>
+            <span>{entries.length}件</span>
+          </header>
+          <ul>
+            {entries.map((entry) => (
+              <li key={entry.id}>
+                <div className="encyclopedia-list__thumb" aria-hidden>{entry.thumbnail ?? '🔬'}</div>
+                <div className="encyclopedia-list__info">
+                  <div className="encyclopedia-list__title">
+                    <h4>{entry.name}</h4>
+                    <button type="button" onClick={() => toggleFavorite(entry.id)}>
+                      {entry.favorite ? '★' : '☆'}
+                    </button>
+                  </div>
+                  <p>{entry.description}</p>
+                  <dl>
+                    {Object.entries(entry.details).map(([key, value]) => (
+                      <div key={key}>
+                        <dt>{key}</dt>
+                        <dd>{value}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                  <footer>
+                    <span>発見: {new Date(entry.discoveredAt).toLocaleString()}</span>
+                    {entry.conditions && <span>条件: {entry.conditions}</span>}
+                  </footer>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+      {!grouped.length && <p className="empty">まだ図鑑データがありません。</p>}
+    </div>
+  );
+};

--- a/src/features/encyclopedia/ui/encyclopedia-list.css
+++ b/src/features/encyclopedia/ui/encyclopedia-list.css
@@ -1,0 +1,102 @@
+.encyclopedia-list {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.encyclopedia-list section {
+  background: rgba(6, 10, 20, 0.85);
+  border-radius: 20px;
+  border: 1px solid rgba(129, 212, 250, 0.15);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.encyclopedia-list section header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  border-bottom: 1px solid rgba(129, 212, 250, 0.12);
+  padding-bottom: 0.75rem;
+}
+
+.encyclopedia-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.encyclopedia-list li {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 1rem;
+  align-items: center;
+  background: rgba(11, 18, 32, 0.9);
+  border-radius: 16px;
+  padding: 1rem;
+  border: 1px solid rgba(129, 212, 250, 0.1);
+}
+
+.encyclopedia-list__thumb {
+  font-size: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.encyclopedia-list__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.encyclopedia-list__title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.encyclopedia-list__title button {
+  background: transparent;
+  border: none;
+  font-size: 1.4rem;
+  cursor: pointer;
+  color: #ffd700;
+}
+
+.encyclopedia-list__info p {
+  margin: 0;
+  color: rgba(200, 220, 255, 0.75);
+}
+
+.encyclopedia-list__info dl {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.4rem 1rem;
+  margin: 0;
+}
+
+.encyclopedia-list__info dt {
+  font-weight: 600;
+  color: rgba(129, 212, 250, 0.85);
+}
+
+.encyclopedia-list__info dd {
+  margin: 0;
+}
+
+.encyclopedia-list__info footer {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.85rem;
+  color: rgba(180, 210, 240, 0.6);
+  flex-wrap: wrap;
+}
+
+.encyclopedia-list .empty {
+  text-align: center;
+  color: rgba(180, 200, 230, 0.7);
+}

--- a/src/features/feed-organism/ui/FeedPanel.tsx
+++ b/src/features/feed-organism/ui/FeedPanel.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { useSimulation } from '../../../app/providers/SimulationProvider';
+import { feedWithType } from '../../../shared/config/store';
+import type { FoodType } from '../../../entities/food/model/types';
+import './feed-panel.css';
+
+const foodLabels: Record<FoodType, string> = {
+  high: '高栄養',
+  low: '低栄養',
+  toxic: '毒性'
+};
+
+export const FeedPanel = () => {
+  const { feed } = useSimulation();
+  const [amount, setAmount] = useState(45);
+  const [type, setType] = useState<FoodType>('high');
+
+  const handleFeed = () => {
+    feed(feedWithType(type, amount));
+  };
+
+  return (
+    <section className="feed-panel">
+      <header>
+        <h2>エサ散布</h2>
+        <p>エサの種類と量を調整して生態系に影響を与えましょう。</p>
+      </header>
+      <div className="feed-panel__controls">
+        <div className="feed-panel__types">
+          {(Object.keys(foodLabels) as FoodType[]).map((key) => (
+            <button
+              key={key}
+              type="button"
+              className={key === type ? 'is-active' : ''}
+              onClick={() => setType(key)}
+            >
+              {foodLabels[key]}
+            </button>
+          ))}
+        </div>
+        <label className="feed-panel__slider">
+          <span>量: {amount.toFixed(0)}</span>
+          <input
+            type="range"
+            min={10}
+            max={120}
+            step={5}
+            value={amount}
+            onChange={(event) => setAmount(Number.parseInt(event.target.value, 10))}
+          />
+        </label>
+      </div>
+      <button type="button" className="feed-panel__action" onClick={handleFeed}>
+        散布する
+      </button>
+    </section>
+  );
+};

--- a/src/features/feed-organism/ui/feed-panel.css
+++ b/src/features/feed-organism/ui/feed-panel.css
@@ -1,0 +1,81 @@
+.feed-panel {
+  background: rgba(9, 15, 28, 0.8);
+  border: 1px solid rgba(129, 212, 250, 0.2);
+  padding: 1.5rem;
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 18px 40px rgba(3, 12, 25, 0.5);
+}
+
+.feed-panel header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.feed-panel header p {
+  margin: 0.4rem 0 0;
+  color: rgba(220, 235, 255, 0.7);
+}
+
+.feed-panel__controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.feed-panel__types {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.feed-panel__types button {
+  padding: 0.75rem 0.5rem;
+  border-radius: 14px;
+  border: 1px solid rgba(129, 212, 250, 0.3);
+  background: transparent;
+  color: rgba(212, 242, 255, 0.75);
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.feed-panel__types button:hover {
+  color: #fff;
+  border-color: rgba(129, 212, 250, 0.6);
+}
+
+.feed-panel__types button.is-active {
+  background: linear-gradient(120deg, rgba(129, 212, 250, 0.6), rgba(206, 147, 216, 0.6));
+  border-color: transparent;
+  color: #041225;
+  box-shadow: 0 12px 24px rgba(129, 212, 250, 0.25);
+}
+
+.feed-panel__slider {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-weight: 600;
+}
+
+.feed-panel__slider input[type='range'] {
+  accent-color: #81d4fa;
+}
+
+.feed-panel__action {
+  align-self: flex-end;
+  padding: 0.75rem 1.6rem;
+  background: linear-gradient(120deg, rgba(129, 212, 250, 0.75), rgba(126, 249, 200, 0.75));
+  border: none;
+  border-radius: 999px;
+  color: #041225;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 14px 35px rgba(129, 212, 250, 0.4);
+}
+
+.feed-panel__action:hover {
+  transform: translateY(-1px);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { RouterProvider } from 'react-router-dom';
+import { AppRouter } from './app/routes';
+import { SimulationProvider } from './app/providers/SimulationProvider';
+import './app/styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <SimulationProvider>
+      <RouterProvider router={AppRouter} />
+    </SimulationProvider>
+  </React.StrictMode>
+);

--- a/src/pages/encyclopedia/ui/EncyclopediaPage.tsx
+++ b/src/pages/encyclopedia/ui/EncyclopediaPage.tsx
@@ -1,0 +1,54 @@
+import { ChangeEvent } from 'react';
+import { EncyclopediaList } from '../../../features/encyclopedia/ui/EncyclopediaList';
+import { useSimulation } from '../../../app/providers/SimulationProvider';
+import type { EncyclopediaEntry } from '../../../entities/encyclopediaEntry/model/types';
+import './encyclopedia-page.css';
+
+const download = (entries: EncyclopediaEntry[]) => {
+  const blob = new Blob([JSON.stringify(entries, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `petri-verse-encyclopedia-${Date.now()}.json`;
+  document.body.append(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+};
+
+export const EncyclopediaPage = () => {
+  const { encyclopedia, registerDiscovery } = useSimulation();
+
+  const onImport = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    try {
+      const parsed = JSON.parse(text) as EncyclopediaEntry[];
+      parsed.forEach((entry) => {
+        registerDiscovery({ ...entry, discoveredAt: entry.discoveredAt ?? Date.now() });
+      });
+    } catch (error) {
+      console.error('Failed to import encyclopedia', error);
+    }
+  };
+
+  return (
+    <div className="encyclopedia-page">
+      <header>
+        <h2>PetriVerse 図鑑</h2>
+        <p>観測済みの微生物・捕食者・環境イベントが自動登録されます。</p>
+        <div className="encyclopedia-page__actions">
+          <button type="button" onClick={() => download(encyclopedia)}>
+            JSONとしてエクスポート
+          </button>
+          <label className="import-label">
+            JSONをインポート
+            <input type="file" accept="application/json" onChange={onImport} />
+          </label>
+        </div>
+      </header>
+      <EncyclopediaList />
+    </div>
+  );
+};

--- a/src/pages/encyclopedia/ui/encyclopedia-page.css
+++ b/src/pages/encyclopedia/ui/encyclopedia-page.css
@@ -1,0 +1,54 @@
+.encyclopedia-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.encyclopedia-page header {
+  background: rgba(7, 12, 22, 0.85);
+  border: 1px solid rgba(129, 212, 250, 0.15);
+  border-radius: 20px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.encyclopedia-page header h2 {
+  margin: 0;
+}
+
+.encyclopedia-page header p {
+  margin: 0;
+  color: rgba(200, 220, 255, 0.75);
+}
+
+.encyclopedia-page__actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.encyclopedia-page__actions button,
+.encyclopedia-page__actions .import-label {
+  padding: 0.8rem 1.4rem;
+  border-radius: 14px;
+  border: 1px solid rgba(129, 212, 250, 0.35);
+  background: rgba(10, 18, 32, 0.85);
+  color: rgba(220, 240, 255, 0.9);
+  cursor: pointer;
+  position: relative;
+  font-weight: 600;
+}
+
+.encyclopedia-page__actions button:hover,
+.encyclopedia-page__actions .import-label:hover {
+  background: rgba(129, 212, 250, 0.2);
+}
+
+.import-label input[type='file'] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}

--- a/src/pages/main/ui/MainPage.tsx
+++ b/src/pages/main/ui/MainPage.tsx
@@ -1,0 +1,16 @@
+import { ObservationScene } from '../../../widgets/observationScene/ui/ObservationScene';
+import { FeedPanel } from '../../../features/feed-organism/ui/FeedPanel';
+import { EnvironmentControl } from '../../../widgets/environmentControl/ui/EnvironmentControl';
+import { EvolutionHistory } from '../../../widgets/evolutionHistory/ui/EvolutionHistory';
+import './main-page.css';
+
+export const MainPage = () => (
+  <div className="main-page">
+    <ObservationScene />
+    <div className="main-page__grid">
+      <FeedPanel />
+      <EnvironmentControl />
+      <EvolutionHistory />
+    </div>
+  </div>
+);

--- a/src/pages/main/ui/main-page.css
+++ b/src/pages/main/ui/main-page.css
@@ -1,0 +1,11 @@
+.main-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.main-page__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}

--- a/src/pages/ranking/ui/RankingPage.tsx
+++ b/src/pages/ranking/ui/RankingPage.tsx
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+import { useSimulation } from '../../../app/providers/SimulationProvider';
+import './ranking-page.css';
+
+export const RankingPage = () => {
+  const { organisms, evolutionLog, encyclopedia, tick } = useSimulation();
+
+  const stats = useMemo(() => {
+    const maxGeneration = organisms.reduce((max, item) => Math.max(max, item.generation), 0);
+    const oldest = organisms.reduce((max, item) => Math.max(max, item.age), 0);
+    const mutationCount = evolutionLog.filter((event) => event.tone === 'mutation').length;
+    const predationCount = evolutionLog.filter((event) => event.tone === 'predation').length;
+    const diversity = new Set(organisms.map((item) => item.traits.shape)).size;
+    const favoriteCount = encyclopedia.filter((entry) => entry.favorite).length;
+
+    return {
+      maxGeneration,
+      oldest,
+      mutationCount,
+      predationCount,
+      diversity,
+      favoriteCount
+    };
+  }, [encyclopedia, evolutionLog, organisms]);
+
+  return (
+    <div className="ranking-page">
+      <header>
+        <h2>ランキング &amp; 指標</h2>
+        <p>現在のシミュレーションのハイライトを集計しています。（tick: {tick.toFixed(0)}）</p>
+      </header>
+      <div className="ranking-page__grid">
+        <article>
+          <h3>最長寿命系統</h3>
+          <p>
+            最も長生きしている個体は <strong>{stats.oldest.toFixed(1)} 秒</strong> 生存中。世代は{' '}
+            <strong>{stats.maxGeneration}</strong> まで到達しています。
+          </p>
+        </article>
+        <article>
+          <h3>突然変異イベント</h3>
+          <p>
+            ログされた突然変異は <strong>{stats.mutationCount}</strong> 件。環境調整やエサの与え方でさらに誘発できます。
+          </p>
+        </article>
+        <article>
+          <h3>捕食者との攻防</h3>
+          <p>
+            捕食イベントは <strong>{stats.predationCount}</strong> 件発生。俊敏型・鈍重型への適応を観察しましょう。
+          </p>
+        </article>
+        <article>
+          <h3>形態多様性</h3>
+          <p>
+            現在観測されている形態タイプは <strong>{stats.diversity}</strong> 種類。突然変異でさらに多様化が期待できます。
+          </p>
+        </article>
+        <article>
+          <h3>図鑑お気に入り</h3>
+          <p>
+            図鑑でお気に入り登録された項目は <strong>{stats.favoriteCount}</strong> 件です。注目の種を共有しましょう。
+          </p>
+        </article>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/ranking/ui/ranking-page.css
+++ b/src/pages/ranking/ui/ranking-page.css
@@ -1,0 +1,52 @@
+.ranking-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.ranking-page header {
+  background: rgba(6, 10, 20, 0.85);
+  border-radius: 20px;
+  border: 1px solid rgba(129, 212, 250, 0.15);
+  padding: 1.5rem;
+}
+
+.ranking-page header h2 {
+  margin: 0;
+}
+
+.ranking-page header p {
+  margin: 0.5rem 0 0;
+  color: rgba(200, 220, 255, 0.7);
+}
+
+.ranking-page__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.ranking-page article {
+  background: rgba(10, 16, 30, 0.85);
+  border-radius: 18px;
+  border: 1px solid rgba(129, 212, 250, 0.15);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ranking-page article h3 {
+  margin: 0;
+  color: rgba(129, 212, 250, 0.9);
+}
+
+.ranking-page article p {
+  margin: 0;
+  line-height: 1.6;
+  color: rgba(200, 220, 255, 0.75);
+}
+
+.ranking-page article strong {
+  color: #7ef9c8;
+}

--- a/src/shared/config/store.ts
+++ b/src/shared/config/store.ts
@@ -1,0 +1,477 @@
+import { useEffect, useMemo, useState } from 'react';
+import { createOrganism, mutateTraits } from '../../entities/organism/lib/createOrganism';
+import type { Organism } from '../../entities/organism/model/types';
+import { createPredator } from '../../entities/predator/lib/createPredator';
+import type { Predator } from '../../entities/predator/model/types';
+import { createEnvironment, clampEnvironment } from '../../entities/environment/lib/createEnvironment';
+import type { Environment } from '../../entities/environment/model/types';
+import { createFoodEvent } from '../../entities/food/lib/createFood';
+import type { FoodEvent, FoodType } from '../../entities/food/model/types';
+import type { EncyclopediaEntry } from '../../entities/encyclopediaEntry/model/types';
+import type { EvolutionEvent } from '../../widgets/evolutionHistory/model/types';
+import { CANVAS_HEIGHT, CANVAS_WIDTH, FOOD_EFFECT, ENVIRONMENT_EFFECT } from '../constants/simulation';
+import { chance, randomInRange, randomItem } from '../lib/random';
+import { nanoid } from '../lib/nanoid';
+import type { SimulationState, SimulationStore } from './types';
+
+const STORAGE_KEY = 'petri-verse::simulation';
+
+const baseDiscoveries: EncyclopediaEntry[] = [
+  {
+    id: 'baseline-environment',
+    name: '標準環境',
+    category: 'environment',
+    description: '温度26℃、酸素0.8、水質pH7の標準的なペトリ環境。',
+    discoveredAt: Date.now(),
+    details: { temperature: '26℃', oxygen: '0.8', pH: 7 },
+    conditions: '初期状態'
+  }
+];
+
+const createInitialState = (): SimulationState => ({
+  tick: 0,
+  organisms: Array.from({ length: 18 }, () => createOrganism()),
+  predators: [],
+  foods: [],
+  environment: createEnvironment(),
+  encyclopedia: baseDiscoveries,
+  evolutionLog: []
+});
+
+const loadState = (): SimulationState | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as SimulationState;
+    return {
+      ...createInitialState(),
+      ...parsed,
+      environment: clampEnvironment(parsed.environment)
+    };
+  } catch (error) {
+    console.warn('Failed to load state', error);
+    return null;
+  }
+};
+
+const persistState = (state: SimulationState) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+};
+
+const bounce = (value: number, velocity: number, min: number, max: number) => {
+  let nextValue = value + velocity;
+  let nextVelocity = velocity;
+  if (nextValue < min) {
+    nextValue = min + (min - nextValue);
+    nextVelocity = Math.abs(velocity);
+  } else if (nextValue > max) {
+    nextValue = max - (nextValue - max);
+    nextVelocity = -Math.abs(velocity);
+  }
+  return { value: nextValue, velocity: nextVelocity };
+};
+
+const decayFood = (food: FoodEvent, delta: number): FoodEvent | null => {
+  const nextAmount = food.amount * Math.pow(1 - food.decay, delta);
+  if (nextAmount < 1) {
+    return null;
+  }
+  return { ...food, amount: nextAmount };
+};
+
+const resolveFoodEnergy = (organism: Organism, foods: FoodEvent[], delta: number): number => {
+  let energyShift = 0;
+  foods.forEach((food) => {
+    const modifier = FOOD_EFFECT[food.type];
+    if (food.type === 'toxic') {
+      energyShift += (organism.traits.preferredFood === 'toxic' ? modifier * 0.3 : modifier) * delta;
+    } else {
+      const affinity = organism.traits.preferredFood === food.type ? 1 : 0.4;
+      energyShift += modifier * affinity * (food.amount / 60) * delta;
+    }
+  });
+  return energyShift;
+};
+
+const environmentalPressure = (organism: Organism, environment: Environment, delta: number): number => {
+  const { temperature, oxygen, acidity } = environment;
+  const tempPenalty = Math.abs(temperature - ENVIRONMENT_EFFECT.temperature.optimal) / ENVIRONMENT_EFFECT.temperature.range;
+  const oxygenPenalty = Math.abs(oxygen - ENVIRONMENT_EFFECT.oxygen.optimal) / ENVIRONMENT_EFFECT.oxygen.range;
+  const acidityPenalty = Math.abs(acidity - ENVIRONMENT_EFFECT.acidity.optimal) / ENVIRONMENT_EFFECT.acidity.range;
+  const resilience = organism.traits.resilience;
+  return -(tempPenalty + oxygenPenalty + acidityPenalty) * 4 * (1 - resilience * 0.6) * delta;
+};
+
+const predatorPressure = (
+  organism: Organism,
+  predators: Predator[],
+  delta: number
+): { energy: number; status: Organism['status'] } => {
+  if (!predators.length) {
+    return { energy: 0, status: 'idle' };
+  }
+  let closest = Infinity;
+  predators.forEach((predator) => {
+    const dx = predator.position.x - organism.position.x;
+    const dy = predator.position.y - organism.position.y;
+    const distance = Math.sqrt(dx * dx + dy * dy);
+    if (distance < closest) {
+      closest = distance;
+    }
+  });
+  if (closest < 80) {
+    return { energy: -8 * delta, status: 'evading' };
+  }
+  return { energy: 0, status: 'idle' };
+};
+
+const limitLog = (log: EvolutionEvent[]): EvolutionEvent[] => log.slice(0, 40);
+
+const upsertDiscovery = (entries: EncyclopediaEntry[], entry: EncyclopediaEntry): EncyclopediaEntry[] => {
+  if (entries.some((item) => item.id === entry.id)) {
+    return entries;
+  }
+  return [entry, ...entries];
+};
+
+export const useLocalSimulationStore = (): SimulationStore => {
+  const [state, setState] = useState<SimulationState>(() => loadState() ?? createInitialState());
+
+  useEffect(() => {
+    persistState(state);
+  }, [state]);
+
+  const addLog = (entry: EvolutionEvent) => {
+    setState((prev) => ({
+      ...prev,
+      evolutionLog: limitLog([entry, ...prev.evolutionLog])
+    }));
+  };
+
+  const advance = (delta: number) => {
+    setState((prev) => {
+      const nextTick = prev.tick + delta;
+      const foods = prev.foods
+        .map((food) => decayFood(food, delta))
+        .filter((value): value is FoodEvent => value !== null);
+
+      const predators: Predator[] = [];
+      const predatorLog: EvolutionEvent[] = [];
+      prev.predators.forEach((predator) => {
+        const age = predator.age + delta;
+        if (age > predator.lifespan) {
+          predatorLog.push({
+            id: nanoid(),
+            createdAt: Date.now(),
+            generation: 0,
+            tone: 'predation',
+            message: predator.behavior === 'agile' ? '俊敏な捕食者が嵐のように去っていった。' : '鈍重な捕食者が静かに姿を消した。'
+          });
+          return;
+        }
+        const { value: x, velocity: vx } = bounce(
+          predator.position.x,
+          predator.velocity.x * (delta * 0.4),
+          30,
+          CANVAS_WIDTH - 30
+        );
+        const { value: y, velocity: vy } = bounce(
+          predator.position.y,
+          predator.velocity.y * (delta * 0.4),
+          30,
+          CANVAS_HEIGHT - 30
+        );
+        predators.push({
+          ...predator,
+          age,
+          position: { x, y },
+          velocity: { x: vx, y: vy }
+        });
+      });
+
+      const organismLog: EvolutionEvent[] = [...predatorLog];
+      const newOrganisms: Organism[] = [];
+      const offspring: Organism[] = [];
+      let encyclopedia = prev.encyclopedia;
+
+      prev.organisms.forEach((organism) => {
+        let age = organism.age + delta;
+        let energy = organism.energy - delta * 1.2 + resolveFoodEnergy(organism, foods, delta);
+        energy += environmentalPressure(organism, prev.environment, delta);
+        const predatorImpact = predatorPressure(organism, predators, delta);
+        energy += predatorImpact.energy;
+        const { value: x, velocity: vx } = bounce(
+          organism.position.x,
+          organism.velocity.x * (delta * 0.25 + organism.traits.speed * 0.008),
+          20,
+          CANVAS_WIDTH - 20
+        );
+        const { value: y, velocity: vy } = bounce(
+          organism.position.y,
+          organism.velocity.y * (delta * 0.25 + organism.traits.speed * 0.008),
+          20,
+          CANVAS_HEIGHT - 20
+        );
+
+        let status: Organism['status'] = predatorImpact.status;
+
+        const predatorThreat = predators.find((predator) => {
+          const dx = predator.position.x - x;
+          const dy = predator.position.y - y;
+          const distance = Math.sqrt(dx * dx + dy * dy);
+          return distance < predator.size * 0.5 + organism.size;
+        });
+        if (predatorThreat) {
+          organismLog.unshift({
+            id: nanoid(),
+            tone: 'predation',
+            createdAt: Date.now(),
+            generation: organism.generation,
+            message: `${organism.generation}世代の微生物が捕食者に捕食された。`
+          });
+          return;
+        }
+
+        if (age > organism.lifespan || energy < -20) {
+          organismLog.unshift({
+            id: nanoid(),
+            tone: 'environment',
+            createdAt: Date.now(),
+            generation: organism.generation,
+            message: `${organism.generation}世代の微生物が寿命を迎えた。`
+          });
+          return;
+        }
+
+        const reproductionChance = organism.traits.fertility * (1 + prev.environment.oxygen) * delta;
+        if (energy > 120 && chance(Math.min(0.8, reproductionChance))) {
+          const child = createOrganism({
+            generation: organism.generation + 1,
+            parentTraits: mutateTraits(organism.traits),
+            position: { x: x + randomInRange(-25, 25), y: y + randomInRange(-25, 25) }
+          });
+          offspring.push(child);
+          status = 'mutating';
+          const discovery: EncyclopediaEntry = {
+            id: `organism-gen-${child.generation}`,
+            name: `${child.generation}世代種`,
+            category: 'organism',
+            description: '突然変異により生まれた新しい系統。',
+            discoveredAt: Date.now(),
+            details: {
+              speed: child.traits.speed.toFixed(1),
+              resilience: child.traits.resilience.toFixed(2),
+              preference: child.traits.preferredFood
+            },
+            conditions: `${child.generation}世代を観測`
+          };
+          encyclopedia = upsertDiscovery(encyclopedia, discovery);
+          organismLog.unshift({
+            id: nanoid(),
+            tone: 'mutation',
+            createdAt: Date.now(),
+            generation: child.generation,
+            message: `突然変異が発生し、新たな第${child.generation}世代が誕生！`
+          });
+        }
+
+        const mutationChance = prev.environment.mutationRate * delta;
+        if (chance(mutationChance * 0.5)) {
+          const mutatedTraits = mutateTraits(organism.traits);
+          organismLog.unshift({
+            id: nanoid(),
+            tone: 'mutation',
+            createdAt: Date.now(),
+            generation: organism.generation,
+            message: `微生物が環境に適応する形で特性を変化させた。`
+          });
+          const entry: EncyclopediaEntry = {
+            id: `mutation-${nanoid()}`,
+            name: '特性変異',
+            category: 'event',
+            description: '環境圧への適応で特性が再編された記録。',
+            discoveredAt: Date.now(),
+            details: {
+              generation: organism.generation,
+              speed: mutatedTraits.speed.toFixed(1),
+              resilience: mutatedTraits.resilience.toFixed(2)
+            },
+            conditions: '突然変異イベント発生'
+          };
+          encyclopedia = upsertDiscovery(encyclopedia, entry);
+          organism = {
+            ...organism,
+            traits: mutatedTraits,
+            size: Math.max(6, Math.min(22, organism.size + randomInRange(-1.5, 1.5)))
+          };
+        }
+
+        newOrganisms.push({
+          ...organism,
+          age,
+          energy: Math.max(-40, Math.min(160, energy)),
+          position: { x, y },
+          velocity: { x: vx, y: vy },
+          status
+        });
+      });
+
+      let environment = prev.environment;
+      if (!environment.event && chance(0.01 * delta)) {
+        const events = [
+          {
+            name: '微隕石の飛来',
+            effect: (env: Environment) => ({
+              ...env,
+              mutationRate: Math.min(0.4, env.mutationRate + 0.05)
+            }),
+            tone: 'environment',
+            message: '微隕石が降り注ぎ、突然変異率が上昇した。'
+          },
+          {
+            name: '外来種の侵入',
+            effect: (env: Environment) => ({
+              ...env,
+              oxygen: Math.max(0.3, env.oxygen - 0.1)
+            }),
+            tone: 'predation',
+            message: '外来種が侵入し、酸素濃度が低下した。'
+          }
+        ];
+        const selected = randomItem(events);
+        environment = {
+          ...selected.effect(environment),
+          event: { name: selected.name, expiresAt: Date.now() + 60_000 }
+        };
+        const entry: EncyclopediaEntry = {
+          id: `event-${selected.name}`,
+          name: selected.name,
+          category: 'event',
+          description: '環境が大きく揺らいだ記録。',
+          discoveredAt: Date.now(),
+          details: { mutationRate: environment.mutationRate.toFixed(2), oxygen: environment.oxygen.toFixed(2) },
+          conditions: 'イベント発生'
+        };
+        encyclopedia = upsertDiscovery(encyclopedia, entry);
+        organismLog.unshift({
+          id: nanoid(),
+          tone: selected.tone,
+          createdAt: Date.now(),
+          generation: 0,
+          message: selected.message
+        });
+      } else if (environment.event && environment.event.expiresAt < Date.now()) {
+        environment = { ...environment, event: undefined };
+      }
+
+      if (chance(0.02 * delta) && predators.length < 2) {
+        const predator = createPredator();
+        predators.push(predator);
+        const entry: EncyclopediaEntry = {
+          id: `predator-${predator.behavior}`,
+          name: predator.behavior === 'agile' ? '俊敏捕食者' : '鈍重捕食者',
+          category: 'predator',
+          description: 'ペトリバースに出現する自然の捕食者。',
+          discoveredAt: Date.now(),
+          details: {
+            lifespan: predator.lifespan.toFixed(0),
+            behavior: predator.behavior,
+            size: predator.size.toFixed(0)
+          },
+          conditions: '捕食者の出現'
+        };
+        encyclopedia = upsertDiscovery(encyclopedia, entry);
+        organismLog.unshift({
+          id: predator.id,
+          tone: 'predation',
+          createdAt: Date.now(),
+          generation: 0,
+          message: predator.behavior === 'agile' ? '俊敏型の捕食者が波紋とともに出現！' : '鈍重型の捕食者が影を落として現れた。'
+        });
+      }
+
+      const combinedOrganisms = [...newOrganisms, ...offspring];
+
+      const evolutionLog = limitLog([...organismLog, ...prev.evolutionLog]);
+
+      return {
+        tick: nextTick,
+        organisms: combinedOrganisms,
+        predators,
+        foods,
+        environment,
+        encyclopedia,
+        evolutionLog
+      };
+    });
+  };
+
+  const feed = (food: FoodEvent) => {
+    setState((prev) => ({
+      ...prev,
+      foods: [food, ...prev.foods]
+    }));
+    addLog({
+      id: food.id,
+      createdAt: Date.now(),
+      generation: 0,
+      tone: food.type === 'toxic' ? 'environment' : 'mutation',
+      message: `ユーザーが${food.type === 'high' ? '高栄養' : food.type === 'low' ? '低栄養' : '毒性'}エサを散布。`
+    });
+  };
+
+  const adjustEnvironment = (partial: Partial<Environment>) => {
+    setState((prev) => ({
+      ...prev,
+      environment: clampEnvironment({ ...prev.environment, ...partial })
+    }));
+  };
+
+  const registerDiscovery = (entry: EncyclopediaEntry) => {
+    setState((prev) => ({
+      ...prev,
+      encyclopedia: upsertDiscovery(prev.encyclopedia, entry)
+    }));
+    addLog({
+      id: entry.id,
+      createdAt: entry.discoveredAt,
+      generation: 0,
+      tone: 'discovery',
+      message: `${entry.name} を図鑑に登録しました。`
+    });
+  };
+
+  const toggleFavorite = (id: string) => {
+    setState((prev) => ({
+      ...prev,
+      encyclopedia: prev.encyclopedia.map((item) => (item.id === id ? { ...item, favorite: !item.favorite } : item))
+    }));
+  };
+
+  const reset = () => {
+    const next = createInitialState();
+    setState(next);
+    persistState(next);
+  };
+
+  return useMemo(
+    () => ({
+      ...state,
+      advance,
+      feed,
+      adjustEnvironment,
+      registerDiscovery,
+      toggleFavorite,
+      reset
+    }),
+    [state]
+  );
+};
+
+export const feedWithType = (type: FoodType, amount: number): FoodEvent => createFoodEvent(type, amount);

--- a/src/shared/config/types.ts
+++ b/src/shared/config/types.ts
@@ -1,0 +1,27 @@
+import type { Organism } from '../../entities/organism/model/types';
+import type { Predator } from '../../entities/predator/model/types';
+import type { Environment } from '../../entities/environment/model/types';
+import type { FoodEvent } from '../../entities/food/model/types';
+import type { EncyclopediaEntry } from '../../entities/encyclopediaEntry/model/types';
+import type { EvolutionEvent } from '../../widgets/evolutionHistory/model/types';
+
+export interface SimulationState {
+  tick: number;
+  organisms: Organism[];
+  predators: Predator[];
+  foods: FoodEvent[];
+  environment: Environment;
+  encyclopedia: EncyclopediaEntry[];
+  evolutionLog: EvolutionEvent[];
+}
+
+export interface SimulationActions {
+  advance: (delta: number) => void;
+  feed: (food: FoodEvent) => void;
+  adjustEnvironment: (environment: Partial<Environment>) => void;
+  registerDiscovery: (entry: EncyclopediaEntry) => void;
+  toggleFavorite: (id: string) => void;
+  reset: () => void;
+}
+
+export type SimulationStore = SimulationState & SimulationActions;

--- a/src/shared/constants/simulation.ts
+++ b/src/shared/constants/simulation.ts
@@ -1,0 +1,23 @@
+export const CANVAS_WIDTH = 640;
+export const CANVAS_HEIGHT = 400;
+
+export const FOOD_EFFECT = {
+  high: 25,
+  low: 12,
+  toxic: -18
+} as const;
+
+export const ENVIRONMENT_EFFECT = {
+  temperature: {
+    optimal: 26,
+    range: 15
+  },
+  oxygen: {
+    optimal: 0.85,
+    range: 0.6
+  },
+  acidity: {
+    optimal: 7,
+    range: 3
+  }
+} as const;

--- a/src/shared/lib/nanoid.ts
+++ b/src/shared/lib/nanoid.ts
@@ -1,0 +1,10 @@
+const alphabet = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+export const nanoid = (size = 12): string => {
+  let id = '';
+  for (let i = 0; i < size; i += 1) {
+    const index = Math.floor(Math.random() * alphabet.length);
+    id += alphabet[index];
+  }
+  return id;
+};

--- a/src/shared/lib/random.ts
+++ b/src/shared/lib/random.ts
@@ -1,0 +1,5 @@
+export const randomInRange = (min: number, max: number): number => Math.random() * (max - min) + min;
+
+export const randomItem = <T>(items: readonly T[]): T => items[Math.floor(Math.random() * items.length)];
+
+export const chance = (probability: number): boolean => Math.random() < probability;

--- a/src/shared/ui/Layout.tsx
+++ b/src/shared/ui/Layout.tsx
@@ -1,0 +1,32 @@
+import { NavLink, Outlet } from 'react-router-dom';
+import './layout.css';
+
+const links = [
+  { to: '/', label: '観察' },
+  { to: '/encyclopedia', label: '図鑑' },
+  { to: '/ranking', label: 'ランキング' }
+];
+
+export const Layout = () => (
+  <div className="layout">
+    <header className="layout__header">
+      <div className="layout__logo">
+        <img src="/logo.svg" alt="PetriVerse" />
+        <div>
+          <h1>PetriVerse</h1>
+          <p>ペトリ皿に広がる小さな宇宙</p>
+        </div>
+      </div>
+      <nav>
+        {links.map((link) => (
+          <NavLink key={link.to} to={link.to} className={({ isActive }) => (isActive ? 'is-active' : '')}>
+            {link.label}
+          </NavLink>
+        ))}
+      </nav>
+    </header>
+    <main className="layout__content">
+      <Outlet />
+    </main>
+  </div>
+);

--- a/src/shared/ui/layout.css
+++ b/src/shared/ui/layout.css
@@ -1,0 +1,69 @@
+.layout {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.layout__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 2rem;
+  background: rgba(11, 18, 33, 0.9);
+  border-bottom: 1px solid rgba(129, 212, 250, 0.2);
+  backdrop-filter: blur(12px);
+}
+
+.layout__logo {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.layout__logo img {
+  width: 48px;
+  height: 48px;
+}
+
+.layout__logo h1 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.layout__logo p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(200, 230, 255, 0.75);
+}
+
+.layout__header nav {
+  display: flex;
+  gap: 1rem;
+  font-weight: 600;
+}
+
+.layout__header a {
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  color: rgba(212, 242, 255, 0.75);
+  transition: all 0.3s ease;
+}
+
+.layout__header a:hover {
+  color: #fff;
+  background: rgba(129, 212, 250, 0.2);
+}
+
+.layout__header a.is-active {
+  background: linear-gradient(120deg, rgba(129, 212, 250, 0.65), rgba(206, 147, 216, 0.6));
+  color: #041225;
+  box-shadow: 0 10px 25px rgba(129, 212, 250, 0.3);
+}
+
+.layout__content {
+  flex: 1;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}

--- a/src/widgets/environmentControl/ui/EnvironmentControl.tsx
+++ b/src/widgets/environmentControl/ui/EnvironmentControl.tsx
@@ -1,0 +1,67 @@
+import { useSimulation } from '../../../app/providers/SimulationProvider';
+import './environment-control.css';
+
+export const EnvironmentControl = () => {
+  const { environment, adjustEnvironment } = useSimulation();
+
+  return (
+    <section className="environment-control">
+      <header>
+        <h2>環境パラメータ</h2>
+        <p>温度・酸素・水質・突然変異率を調整して適応のゆらぎを観察。</p>
+      </header>
+      <div className="environment-control__grid">
+        <label>
+          <span>温度 {environment.temperature.toFixed(1)}℃</span>
+          <input
+            type="range"
+            min={10}
+            max={40}
+            step={0.5}
+            value={environment.temperature}
+            onChange={(event) => adjustEnvironment({ temperature: Number.parseFloat(event.target.value) })}
+          />
+        </label>
+        <label>
+          <span>酸素 {(environment.oxygen * 100).toFixed(0)}%</span>
+          <input
+            type="range"
+            min={0.2}
+            max={1}
+            step={0.01}
+            value={environment.oxygen}
+            onChange={(event) => adjustEnvironment({ oxygen: Number.parseFloat(event.target.value) })}
+          />
+        </label>
+        <label>
+          <span>水質 pH {environment.acidity.toFixed(1)}</span>
+          <input
+            type="range"
+            min={4}
+            max={9}
+            step={0.1}
+            value={environment.acidity}
+            onChange={(event) => adjustEnvironment({ acidity: Number.parseFloat(event.target.value) })}
+          />
+        </label>
+        <label>
+          <span>突然変異率 {(environment.mutationRate * 100).toFixed(1)}%</span>
+          <input
+            type="range"
+            min={0.05}
+            max={0.4}
+            step={0.01}
+            value={environment.mutationRate}
+            onChange={(event) => adjustEnvironment({ mutationRate: Number.parseFloat(event.target.value) })}
+          />
+        </label>
+      </div>
+      {environment.event && (
+        <div className="environment-control__event">
+          <strong>{environment.event.name}</strong>
+          <span>イベント継続中...</span>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/src/widgets/environmentControl/ui/environment-control.css
+++ b/src/widgets/environmentControl/ui/environment-control.css
@@ -1,0 +1,50 @@
+.environment-control {
+  background: rgba(8, 14, 25, 0.85);
+  border: 1px solid rgba(129, 212, 250, 0.2);
+  padding: 1.5rem;
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.environment-control header h2 {
+  margin: 0;
+}
+
+.environment-control header p {
+  margin: 0.4rem 0 0;
+  color: rgba(200, 230, 255, 0.7);
+}
+
+.environment-control__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.environment-control__grid label {
+  background: rgba(12, 20, 34, 0.9);
+  border-radius: 16px;
+  padding: 1rem;
+  border: 1px solid rgba(129, 212, 250, 0.15);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.environment-control__grid input[type='range'] {
+  accent-color: #ce93d8;
+}
+
+.environment-control__event {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.75rem 1rem;
+  border-radius: 16px;
+  background: rgba(255, 159, 243, 0.12);
+  border: 1px solid rgba(255, 159, 243, 0.4);
+  color: #ffb6ff;
+}

--- a/src/widgets/evolutionHistory/model/types.ts
+++ b/src/widgets/evolutionHistory/model/types.ts
@@ -1,0 +1,7 @@
+export interface EvolutionEvent {
+  id: string;
+  message: string;
+  createdAt: number;
+  generation: number;
+  tone: 'mutation' | 'predation' | 'environment' | 'discovery';
+}

--- a/src/widgets/evolutionHistory/ui/EvolutionHistory.tsx
+++ b/src/widgets/evolutionHistory/ui/EvolutionHistory.tsx
@@ -1,0 +1,33 @@
+import { useMemo } from 'react';
+import { useSimulation } from '../../../app/providers/SimulationProvider';
+import './evolution-history.css';
+
+const toneToClass: Record<string, string> = {
+  mutation: 'tone-mutation',
+  predation: 'tone-predation',
+  environment: 'tone-environment',
+  discovery: 'tone-discovery'
+};
+
+export const EvolutionHistory = () => {
+  const { evolutionLog } = useSimulation();
+  const events = useMemo(() => evolutionLog.slice(0, 12), [evolutionLog]);
+
+  return (
+    <section className="evolution-history">
+      <header>
+        <h2>進化ログ</h2>
+        <p>世代交代や環境イベントの履歴。</p>
+      </header>
+      <ul>
+        {events.map((event) => (
+          <li key={event.id} className={toneToClass[event.tone]}>
+            <span className="evolution-history__time">{new Date(event.createdAt).toLocaleTimeString()}</span>
+            <p>{event.message}</p>
+          </li>
+        ))}
+        {!events.length && <li className="empty">まだログがありません。</li>}
+      </ul>
+    </section>
+  );
+};

--- a/src/widgets/evolutionHistory/ui/evolution-history.css
+++ b/src/widgets/evolutionHistory/ui/evolution-history.css
@@ -1,0 +1,73 @@
+.evolution-history {
+  background: rgba(6, 12, 22, 0.85);
+  border: 1px solid rgba(129, 212, 250, 0.15);
+  border-radius: 20px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.evolution-history header h2 {
+  margin: 0;
+}
+
+.evolution-history header p {
+  margin: 0.4rem 0 0;
+  color: rgba(200, 220, 255, 0.7);
+}
+
+.evolution-history ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.evolution-history li {
+  background: rgba(11, 18, 32, 0.9);
+  border-radius: 14px;
+  padding: 0.9rem 1rem;
+  border: 1px solid rgba(129, 212, 250, 0.15);
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.evolution-history li.empty {
+  justify-content: center;
+  text-align: center;
+  color: rgba(180, 200, 230, 0.6);
+  display: flex;
+}
+
+.evolution-history__time {
+  font-variant-numeric: tabular-nums;
+  color: rgba(160, 220, 255, 0.8);
+}
+
+.evolution-history li p {
+  margin: 0;
+  line-height: 1.4;
+}
+
+.tone-mutation {
+  border-left: 4px solid rgba(126, 249, 200, 0.8);
+}
+
+.tone-predation {
+  border-left: 4px solid rgba(255, 128, 171, 0.8);
+}
+
+.tone-environment {
+  border-left: 4px solid rgba(129, 212, 250, 0.8);
+}
+
+.tone-discovery {
+  border-left: 4px solid rgba(255, 214, 165, 0.8);
+}

--- a/src/widgets/observationScene/ui/ObservationScene.tsx
+++ b/src/widgets/observationScene/ui/ObservationScene.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useRef } from 'react';
+import { useSimulation } from '../../../app/providers/SimulationProvider';
+import { CANVAS_HEIGHT, CANVAS_WIDTH } from '../../../shared/constants/simulation';
+import type { Organism } from '../../../entities/organism/model/types';
+import type { Predator } from '../../../entities/predator/model/types';
+import './observation-scene.css';
+
+const drawOrganism = (ctx: CanvasRenderingContext2D, organism: Organism) => {
+  ctx.save();
+  ctx.translate(organism.position.x, organism.position.y);
+  if (organism.status === 'mutating') {
+    const glow = ctx.createRadialGradient(0, 0, 0, 0, 0, organism.size * 1.8);
+    glow.addColorStop(0, `${organism.traits.color}AA`);
+    glow.addColorStop(1, '#ffffff00');
+    ctx.fillStyle = glow;
+    ctx.beginPath();
+    ctx.arc(0, 0, organism.size * 1.8, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  if (organism.status === 'evading') {
+    ctx.shadowBlur = 15;
+    ctx.shadowColor = '#5dade2aa';
+  }
+
+  ctx.fillStyle = organism.traits.color;
+  ctx.strokeStyle = '#0b0f1a';
+  ctx.lineWidth = 1.2;
+
+  switch (organism.traits.shape) {
+    case 'amoeba': {
+      ctx.beginPath();
+      for (let i = 0; i < 6; i += 1) {
+        const angle = (Math.PI * 2 * i) / 6;
+        const radius = organism.size + Math.sin(organism.age + i) * 4;
+        const x = Math.cos(angle) * radius;
+        const y = Math.sin(angle) * radius;
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.quadraticCurveTo(x, y, x, y);
+      }
+      ctx.closePath();
+      ctx.fill();
+      break;
+    }
+    case 'spike': {
+      ctx.beginPath();
+      const spikes = 12;
+      const outer = organism.size * 1.2;
+      const inner = organism.size * 0.6;
+      for (let i = 0; i < spikes * 2; i += 1) {
+        const radius = i % 2 === 0 ? outer : inner;
+        const angle = (Math.PI * i) / spikes;
+        const x = Math.cos(angle) * radius;
+        const y = Math.sin(angle) * radius;
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.closePath();
+      ctx.fill();
+      break;
+    }
+    default: {
+      ctx.beginPath();
+      ctx.arc(0, 0, organism.size, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  ctx.globalAlpha = 0.9;
+  ctx.beginPath();
+  ctx.arc(-organism.size * 0.3, -organism.size * 0.4, organism.size * 0.4, 0, Math.PI * 2);
+  ctx.fillStyle = '#ffffff22';
+  ctx.fill();
+
+  ctx.restore();
+};
+
+const drawPredator = (ctx: CanvasRenderingContext2D, predator: Predator) => {
+  ctx.save();
+  ctx.translate(predator.position.x, predator.position.y);
+
+  const ripple = ctx.createRadialGradient(0, 0, predator.size * 0.3, 0, 0, predator.size * 1.4);
+  ripple.addColorStop(0, '#2ecc7140');
+  ripple.addColorStop(1, '#ffffff00');
+  ctx.fillStyle = ripple;
+  ctx.beginPath();
+  ctx.arc(0, 0, predator.size * 1.4, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.shadowBlur = 20;
+  ctx.shadowColor = predator.behavior === 'agile' ? '#ff9ff3aa' : '#5dade2aa';
+  ctx.fillStyle = predator.behavior === 'agile' ? '#ff6b81' : '#1abc9c';
+  ctx.beginPath();
+  ctx.ellipse(0, 0, predator.size, predator.size * 0.6, Math.sin(predator.age) * 0.5, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.restore();
+};
+
+const drawEnvironmentOverlay = (
+  ctx: CanvasRenderingContext2D,
+  params: { temperature: number; oxygen: number; acidity: number; eventName?: string }
+) => {
+  ctx.save();
+  ctx.fillStyle = '#0b0f1a66';
+  ctx.fillRect(12, 12, 215, params.eventName ? 120 : 90);
+  ctx.fillStyle = '#d6f3ff';
+  ctx.font = '14px "Segoe UI", sans-serif';
+  ctx.fillText(`温度: ${params.temperature.toFixed(1)}℃`, 24, 40);
+  ctx.fillText(`酸素: ${(params.oxygen * 100).toFixed(0)}%`, 24, 62);
+  ctx.fillText(`pH: ${params.acidity.toFixed(1)}`, 24, 84);
+  if (params.eventName) {
+    ctx.fillStyle = '#ff9ff3';
+    ctx.fillText(`イベント: ${params.eventName}`, 24, 106);
+  }
+  ctx.restore();
+};
+
+const renderScene = (
+  canvas: HTMLCanvasElement,
+  organisms: Organism[],
+  predators: Predator[],
+  environment: { temperature: number; oxygen: number; acidity: number; event?: { name: string } }
+) => {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  ctx.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+  const gradient = ctx.createLinearGradient(0, 0, 0, CANVAS_HEIGHT);
+  gradient.addColorStop(0, '#06162b');
+  gradient.addColorStop(1, '#02070f');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+  predators.forEach((predator) => drawPredator(ctx, predator));
+  organisms.forEach((organism) => drawOrganism(ctx, organism));
+  drawEnvironmentOverlay(ctx, {
+    temperature: environment.temperature,
+    oxygen: environment.oxygen,
+    acidity: environment.acidity,
+    eventName: environment.event?.name
+  });
+};
+
+export const ObservationScene = () => {
+  const { organisms, predators, environment, advance } = useSimulation();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    let animationFrame = 0;
+    let last = performance.now();
+
+    const loop = (time: number) => {
+      const delta = Math.min(1.5, (time - last) / 1000);
+      last = time;
+      advance(delta);
+      animationFrame = requestAnimationFrame(loop);
+    };
+
+    animationFrame = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(animationFrame);
+  }, [advance]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    renderScene(canvas, organisms, predators, environment);
+  }, [organisms, predators, environment]);
+
+  return (
+    <div className="observation-scene">
+      <canvas ref={canvasRef} width={CANVAS_WIDTH} height={CANVAS_HEIGHT} />
+    </div>
+  );
+};

--- a/src/widgets/observationScene/ui/observation-scene.css
+++ b/src/widgets/observationScene/ui/observation-scene.css
@@ -1,0 +1,11 @@
+.observation-scene {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.observation-scene canvas {
+  border-radius: 24px;
+  box-shadow: 0 30px 60px rgba(3, 12, 25, 0.6);
+  border: 1px solid rgba(129, 212, 250, 0.25);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: '0.0.0.0',
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- implement a simulation store that drives organisms, predators, environment events, and localStorage persistence
- create the observation scene canvas renderer with mutation and predation effects plus supporting widgets
- add encyclopedia, ranking, and layout pages to navigate the PetriVerse experience

## Testing
- npm install *(fails: registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d05875434c8323bd4237faa3985844